### PR TITLE
Update isFontDisplaySupported check

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -23,8 +23,7 @@
     (document.head || document.body).appendChild(style);
   }
 
-  var isFontDisplaySupported =
-    window.FontFace && window.FontFace.prototype.hasOwnProperty('display');
+  var isFontDisplaySupported = document.fonts !== undefined;
   if (!isFontDisplaySupported) {
     insertFallback();
     return;


### PR DESCRIPTION
https://css-tricks.com/font-display-masses/ According to that, checking for `"font" in document` is enough.

Also, the check is currently wrong: https://developer.mozilla.org/de/docs/Web/API/FontFace/display - Firefox doesn't support `display` in JS, however it does support `font-display` in CSS: https://caniuse.com/#search=font-display