### PR TITLE
Always use https in the html snippet

### DIFF
--- a/src/snippet.hbs
+++ b/src/snippet.hbs
@@ -1,7 +1,7 @@
 <!-- Code snippet to speed up Google Fonts rendering: googlefonts.3perf.com -->
-<link rel="dns-prefetch" href="//fonts.gstatic.com" />
-<link rel="preconnect" href="//fonts.gstatic.com" />
-<link rel="preload" href="%FONT_STYLESHEET%" as="fetch" crossorigin="anonymous" />
+<link rel="dns-prefetch" href="https://fonts.gstatic.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous">
+<link rel="preload" href="%FONT_STYLESHEET%" as="fetch" crossorigin="anonymous">
 {{!-- %FONT_STYLESHEET% is replaced by the snippet generator when the snippet is generated --}}
 <script type="text/javascript">
 {{{scriptSource}}}


### PR DESCRIPTION
Google Fonts redirects to https anyway - and preconnect has to use crossorigin as well, if the preload uses crossorigin.