### PR TITLE
Allow greater minification

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1,4 +1,4 @@
-(function() {
+(function(window, document, localStorage) {
   'use strict';
 
   // $FONT_STYLESHEET$ and $FONT_DISPLAY$ values are replaced by the snippet generator
@@ -65,4 +65,4 @@
     })
     .then(insertStylesheet)
     .catch(insertFallback);
-})();
+})(window, document, localStorage);


### PR DESCRIPTION
if we "pull" those 3 global variables into the IIFE, Uglify can mangle those variables (= we save a few characters + local variables have faster lookup speed than global ones)