### PR TITLE
fetch -> style for higher priority

### DIFF
--- a/src/snippet.hbs
+++ b/src/snippet.hbs
@@ -1,7 +1,7 @@
 <!-- Code snippet to speed up Google Fonts rendering: googlefonts.3perf.com -->
 <link rel="dns-prefetch" href="https://fonts.gstatic.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous">
-<link rel="preload" href="%FONT_STYLESHEET%" as="fetch" crossorigin="anonymous">
+<link rel="preload" href="%FONT_STYLESHEET%" as="style" crossorigin="anonymous">
 {{!-- %FONT_STYLESHEET% is replaced by the snippet generator when the snippet is generated --}}
 <script type="text/javascript">
 {{{scriptSource}}}


### PR DESCRIPTION
Did you use `fetch` as `as` value with a reason? If not, we should use `style`, as it preloads a stylesheet and gives it `highest` priority instead of `normal` (I think).