### PR TITLE
Move swap to generator now that it's supported by google

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -7,7 +7,7 @@
   // We need a unique ID for a localStorage key and a style tag attribute (see #18 for reasoning).
   // In this script, we reuse the same variable for both meanings
   // to reduce the script size after minification and gzip
-  var uniqueStorageId = '__3perf_googleFonts_%UNIQUE_ID%';
+  var uniqueStorageId = '__3perf_gFonts_%UNIQUE_ID%';
 
   function append(el) {
     (document.head || document.body).appendChild(el);

--- a/src/script.js
+++ b/src/script.js
@@ -31,13 +31,6 @@
     document.getElementById(uniqueStorageId).innerHTML = stylesheet;
   }
 
-  var isFontDisplaySupported =
-    window.FontFace && window.FontFace.prototype.hasOwnProperty('display');
-  if (!isFontDisplaySupported) {
-    insertFallback();
-    return;
-  }
-
   if (localStorage[uniqueStorageId]) {
     // We insert a cached stylesheet syncronously to avoid a FOUT if fonts are cached.
     // This matches the behavior of the original render-blocking `<link rel="stylesheet">` tag.

--- a/src/script.js
+++ b/src/script.js
@@ -21,13 +21,6 @@
     append(link);
   }
 
-  function patchStylesheet(stylesheet) {
-    return stylesheet.replace(
-      /@font-face {/g,
-      '@font-face{font-display:' + fontDisplayValue + ';'
-    );
-  }
-
   function insertStylesheet(stylesheet) {
     if (!document.getElementById(uniqueStorageId)) {
       var style = document.createElement('style');
@@ -58,7 +51,6 @@
     .then(function(response) {
       return response.text();
     })
-    .then(patchStylesheet)
     .then(function(stylesheet) {
       localStorage[uniqueStorageId] = stylesheet;
       return stylesheet;

--- a/src/script.js
+++ b/src/script.js
@@ -1,10 +1,9 @@
 (function(window, document, localStorage) {
   'use strict';
 
-  // %FONT_STYLESHEET%, %FONT_DISPLAY% and %UNIQUE_ID% values are replaced by the snippet generator
+  // %FONT_STYLESHEET% and %UNIQUE_ID% values are replaced by the snippet generator
   // when the snippet is generated
   var fontStylesheet = '%FONT_STYLESHEET%';
-  var fontDisplayValue = '%FONT_DISPLAY%';
   // We need a unique ID for a localStorage key and a style tag attribute (see #18 for reasoning).
   // In this script, we reuse the same variable for both meanings
   // to reduce the script size after minification and gzip

--- a/src/snippet-generator/index.hbs
+++ b/src/snippet-generator/index.hbs
@@ -424,6 +424,13 @@
         const snippet = '{{{snippetSource}}}';
         const uniqueId = Math.floor(Math.random() * 1e6).toString(16);
 
+        const urlParams = new URLSearchParams(fontFamily);
+        const myParam = urlParams.get('display');
+
+        if (!urlParams.get('display')) {
+          fontFamily += "&display=swap"
+        }
+
         return snippet
           .replace(/%FONT_STYLESHEET%/g, fontFamily)
           .replace(/%FONT_DISPLAY%/g, 'swap')


### PR DESCRIPTION
Google now supports font-face swap via query parameter:

https://twitter.com/addyosmani/status/1128548064287952896

yay! 🎉

I still think this script is useful since it's inlined and so removes the need for a render blocking stylesheet -- I've moved the `swap` logic to the generator, and made a few other small tweaks. Let me know what you think.